### PR TITLE
Feat/schelling model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,16 @@ game_of_life:
 game_of_life_exec:
 	java -cp ./lib/gui.jar:./out/ gameoflife.TestGameOfLifeSimulator
 
+immigration_game:
+	javac -cp ./lib/gui.jar:./src/ -d out/ ./src/immigrationgame/TestImmigrationGameSimulator.java
+
+immigration_game_exec:
+	java -cp ./lib/gui.jar:./out/ immigrationgame.TestImmigrationGameSimulator
+
+schelling_model:
+	javac -cp ./lib/gui.jar:./src/ -d out/ ./src/schelling/TestSchellingModelSimulator.java
+
+schelling_model_exec:
+	java -cp ./lib/gui.jar:./out/ schelling.TestSchellingModelSimulator
 clean:
 	rm -rf bin

--- a/src/game/Game.java
+++ b/src/game/Game.java
@@ -35,7 +35,7 @@ public abstract class Game<TState extends CellState>{
     // generics disappear, so you don't know which type of array you are handling.
     // List only
     protected Grid<TState> grid;
-    private final Grid<TState> initialGrid;
+    protected final Grid<TState> initialGrid;
 
     // User sized game
     public Game(int rows, int cols) {

--- a/src/game/Game.java
+++ b/src/game/Game.java
@@ -165,6 +165,9 @@ public abstract class Game<TState extends CellState>{
     /// Calculates next state of the game.
     /// The new state calculated on the "newGrid" based on the
     /// actual state maintained on this.grid
+    ///
+    /// Note: I had to put the newState parameter because I cannot
+    /// instantiate a generic class.
     public void nextState(Game<TState> newState) {
         for  (int row = 0; row < getRows(); row++) {
             for (int column = 0; column < getColumns(); column++) {

--- a/src/game/Game.java
+++ b/src/game/Game.java
@@ -50,8 +50,8 @@ public abstract class Game<TState extends CellState>{
         for (int row = 0; row < rows; row++) {
             for (int column = 0; column < cols; column++) {
                 Cell<TState> cell = new Cell<TState>(row, column, newState());
-                grid.addCell(row, column, cell);
-                initialGrid.addCell(row, column, cell.clone());
+                grid.setCell(row, column, cell);
+                initialGrid.setCell(row, column, cell.clone());
             }
         }
     }
@@ -129,6 +129,9 @@ public abstract class Game<TState extends CellState>{
     }
 
 
+    /*
+        Draws the game on the GUI.
+     */
     public void draw(GUISimulator gui) {
         gui.reset();
         int marcoSizeX = getRows() * CELL_SIZE;

--- a/src/game/Grid.java
+++ b/src/game/Grid.java
@@ -1,8 +1,11 @@
 package game;
 
 import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
-public class Grid<TState extends CellState> {
+public class Grid<TState extends CellState> implements Iterable<Cell<TState>> {
     private ArrayList<ArrayList<Cell<TState>>> cells;
 
     private final int rows;
@@ -13,7 +16,11 @@ public class Grid<TState extends CellState> {
         this.cols = cols;
         this.cells = new ArrayList<>(rows);
         for(int i = 0; i < rows; i++) {
-            cells.add( new ArrayList<>(cols));
+            ArrayList<Cell<TState>> row = new ArrayList<>(cols);
+            for (int j = 0; j < cols; j++) {
+                row.add(null);
+            }
+            cells.add(row);
         }
     }
 
@@ -38,6 +45,13 @@ public class Grid<TState extends CellState> {
         return  cells.get(row).get(column).getState();
     }
 
+    public void setCell(int row, int column, Cell<TState> cell) {
+        if (row < 0 || column < 0 || row >= rows || column >= cols) {
+            throw new IndexOutOfBoundsException("Invalid row or column");
+        }
+        cells.get(row).set(column, cell);
+    }
+
     public void addCell(int row, int column, Cell<TState> cell) {
         if (row < 0 || column < 0 || row >= rows || column >= cols) {
             throw new IndexOutOfBoundsException("Invalid row or column");
@@ -45,10 +59,16 @@ public class Grid<TState extends CellState> {
         cells.get(row).add(column, cell);
     }
 
+    /*
+        Return the number of rows on the grid
+     */
     public int rows() {
         return rows;
     }
 
+    /*
+        Return the number of columns on each row.
+     */
     public int columns() {
         return cols;
     }
@@ -79,5 +99,14 @@ public class Grid<TState extends CellState> {
     // Not good.
     public ArrayList<ArrayList<Cell<TState>>> cells() {
         return cells;
+    }
+
+    @Override
+    public Iterator<Cell<TState>> iterator() {
+        return new GridIterator<>(this);
+    }
+
+    public Stream<Cell<TState>> stream() {
+        return StreamSupport.stream(spliterator(), false);
     }
 }

--- a/src/game/GridIterator.java
+++ b/src/game/GridIterator.java
@@ -1,0 +1,33 @@
+package game;
+
+import java.util.Iterator;
+
+public class GridIterator<TState extends CellState> implements Iterator<Cell<TState>> {
+    private final Grid<TState> cells;
+    private int cursorX;
+    private int cursorY;
+
+    public GridIterator(Grid<TState> cells) {
+        this.cells = cells;
+        this.cursorX = 0;
+        this.cursorY = 0;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return cursorX < cells.rows() && cursorY < cells.columns();
+    }
+
+    @Override
+    public Cell<TState> next() {
+        if (!hasNext())
+            return null;
+        Cell<TState> cell = this.cells.getCell(cursorX, cursorY);
+
+        if (cursorY  == cells.columns() -1)
+            cursorX++;
+        cursorY = (cursorY + 1) % cells.columns();
+
+        return cell;
+    }
+}

--- a/src/gameoflife/GameOfLife.java
+++ b/src/gameoflife/GameOfLife.java
@@ -86,14 +86,7 @@ public class GameOfLife extends Game<LifeState> {
 
     // Game function
     public LifeState cellNextState(Cell<LifeState> cell) {
-        List<Cell<LifeState>> neighbors = this.getCellNeighbors(cell);
-        int aliveNeighbors = 0;
-
-        for (Cell<LifeState> n : neighbors) {
-            if (isAlive(n)) {
-                aliveNeighbors++;
-            }
-        }
+        long aliveNeighbors = this.getCellNeighbors(cell).stream().filter(this::isAlive).count();
 
         if (isAlive(cell)) {
             if (aliveNeighbors == 2 || aliveNeighbors == 3) {

--- a/src/immigrationgame/ImmigrationGame.java
+++ b/src/immigrationgame/ImmigrationGame.java
@@ -48,15 +48,13 @@ public class ImmigrationGame extends Game<ImmigrationState> {
     @Override
     public ImmigrationState cellNextState(Cell<ImmigrationState> cell) {
         List<Cell<ImmigrationState>> neighbors = this.getCellNeighbors(cell);
-        int higherStateNeighbors = 0;
         int cellStatus = cell.getState().getImmigrationState();
         int nextStatus = (cellStatus + 1) % stateNumber;
 
-        for (Cell<ImmigrationState> n : neighbors) {
-            if (n.getState().getImmigrationState() == nextStatus) {
-                higherStateNeighbors++;
-            }
-        }
+        long higherStateNeighbors = this.getCellNeighbors(cell)
+                .stream()
+                .filter(n -> n.getState().getImmigrationState() == nextStatus)
+                .count();
 
         if  (higherStateNeighbors >= 3) {
             return new ImmigrationState(nextStatus);
@@ -64,7 +62,6 @@ public class ImmigrationGame extends Game<ImmigrationState> {
             return new ImmigrationState(cellStatus);
         }
     }
-
 
 
     @Override

--- a/src/schelling/RoomState.java
+++ b/src/schelling/RoomState.java
@@ -44,4 +44,5 @@ public class RoomState implements CellState, Cloneable {
     public RoomValue getRoomValue() {
         return state;
     }
+    public boolean isRoomEmpty() {return this.state == RoomValue.EMPTY;}
 }

--- a/src/schelling/RoomState.java
+++ b/src/schelling/RoomState.java
@@ -11,6 +11,10 @@ public class RoomState implements CellState {
         this.state = randomRoomValue();
     }
 
+    public RoomState(RoomValue roomValue) {
+        this.state = roomValue;
+    }
+
     protected static RoomValue randomRoomValue() {
         Random rand = new Random();
 
@@ -20,17 +24,19 @@ public class RoomState implements CellState {
             case 0 ->
                     RoomValue.BLACK;
             case 1 ->
-                    RoomValue.WHITE;
+                    RoomValue.PINK;
             case 2 ->
                     RoomValue.YELLOW;
             case 3 ->
                     RoomValue.RED;
             case 4 ->
-                    RoomValue.BROWN;
-            case 5, 6, 7, 8 , 9, 10 ->
-                    RoomValue.EMPTY;
+                    RoomValue.ORANGE;
             default->
-                    throw new IllegalStateException("Unexpected value: " + cellState);
+                    RoomValue.EMPTY;
         };
+    }
+
+    public RoomValue getRoomValue() {
+        return state;
     }
 }

--- a/src/schelling/RoomState.java
+++ b/src/schelling/RoomState.java
@@ -1,0 +1,6 @@
+package schelling;
+
+import game.CellState;
+
+public class RoomState implements CellState {
+}

--- a/src/schelling/RoomState.java
+++ b/src/schelling/RoomState.java
@@ -1,13 +1,12 @@
 package schelling;
 
-import game.Cell;
 import game.CellState;
 import java.util.Random;
 import schelling.SchellingConfiguration.RoomValue;
 
 public class RoomState implements CellState, Cloneable {
 
-    private RoomValue state;
+    private final RoomValue state;
     public RoomState() {
         this.state = randomRoomValue();
     }
@@ -24,7 +23,7 @@ public class RoomState implements CellState, Cloneable {
     protected static RoomValue randomRoomValue() {
         Random rand = new Random();
 
-        int cellState = rand.nextInt(SchellingConfiguration.ROOM_VALUES_COUNT + 1);
+        int cellState = rand.nextInt(SchellingConfiguration.ROOM_VALUES_COUNT);
 
         return switch (cellState) {
             case 0 ->

--- a/src/schelling/RoomState.java
+++ b/src/schelling/RoomState.java
@@ -1,6 +1,36 @@
 package schelling;
 
 import game.CellState;
+import java.util.Random;
+import schelling.SchellingConfiguration.RoomValue;
 
 public class RoomState implements CellState {
+
+    private RoomValue state;
+    public RoomState() {
+        this.state = randomRoomValue();
+    }
+
+    protected static RoomValue randomRoomValue() {
+        Random rand = new Random();
+
+        int cellState = rand.nextInt(SchellingConfiguration.ROOM_VALUES_COUNT + 5);
+
+        return switch (cellState) {
+            case 0 ->
+                    RoomValue.BLACK;
+            case 1 ->
+                    RoomValue.WHITE;
+            case 2 ->
+                    RoomValue.YELLOW;
+            case 3 ->
+                    RoomValue.RED;
+            case 4 ->
+                    RoomValue.BROWN;
+            case 5, 6, 7, 8 , 9, 10 ->
+                    RoomValue.EMPTY;
+            default->
+                    throw new IllegalStateException("Unexpected value: " + cellState);
+        };
+    }
 }

--- a/src/schelling/RoomState.java
+++ b/src/schelling/RoomState.java
@@ -1,10 +1,11 @@
 package schelling;
 
+import game.Cell;
 import game.CellState;
 import java.util.Random;
 import schelling.SchellingConfiguration.RoomValue;
 
-public class RoomState implements CellState {
+public class RoomState implements CellState, Cloneable {
 
     private RoomValue state;
     public RoomState() {
@@ -15,10 +16,15 @@ public class RoomState implements CellState {
         this.state = roomValue;
     }
 
+    @Override
+    public RoomState clone() {
+        return new RoomState(this.state);
+    }
+
     protected static RoomValue randomRoomValue() {
         Random rand = new Random();
 
-        int cellState = rand.nextInt(SchellingConfiguration.ROOM_VALUES_COUNT + 5);
+        int cellState = rand.nextInt(SchellingConfiguration.ROOM_VALUES_COUNT + 1);
 
         return switch (cellState) {
             case 0 ->

--- a/src/schelling/SchellingConfiguration.java
+++ b/src/schelling/SchellingConfiguration.java
@@ -1,0 +1,21 @@
+package schelling;
+
+
+
+public class SchellingConfiguration {
+    public static final int ROOM_VALUES_COUNT = RoomValue.values().length;
+    /*
+    This represents the number of different colors neighbors at a given cell with color C
+    needed to decide to change of neighborhood.
+     */
+    public static final int threshold = 6;
+
+    public enum RoomValue {
+        BLACK,
+        WHITE,
+        BROWN,
+        YELLOW,
+        RED,
+        EMPTY
+    };
+}

--- a/src/schelling/SchellingConfiguration.java
+++ b/src/schelling/SchellingConfiguration.java
@@ -8,7 +8,7 @@ public class SchellingConfiguration {
     This represents the number of different colors neighbors at a given cell with color C
     needed to decide to change of neighborhood.
      */
-    public static final int threshold = 6;
+    public static final int threshold = 2;
 
     public enum RoomValue {
         BLACK,

--- a/src/schelling/SchellingConfiguration.java
+++ b/src/schelling/SchellingConfiguration.java
@@ -12,8 +12,8 @@ public class SchellingConfiguration {
 
     public enum RoomValue {
         BLACK,
-        WHITE,
-        BROWN,
+        PINK,
+        ORANGE,
         YELLOW,
         RED,
         EMPTY

--- a/src/schelling/SchellingConfiguration.java
+++ b/src/schelling/SchellingConfiguration.java
@@ -3,12 +3,13 @@ package schelling;
 
 
 public class SchellingConfiguration {
-    public static final int ROOM_VALUES_COUNT = RoomValue.values().length;
+    public static final int EMPTY_ROOMS_PARAMETER = 1;
+    public static final int ROOM_VALUES_COUNT = RoomValue.values().length + EMPTY_ROOMS_PARAMETER;
     /*
     This represents the number of different colors neighbors at a given cell with color C
     needed to decide to change of neighborhood.
      */
-    public static final int threshold = 2;
+    public static final int TOLERANCE_THRESHOLD = 3;
 
     public enum RoomValue {
         BLACK,

--- a/src/schelling/SchellingModel.java
+++ b/src/schelling/SchellingModel.java
@@ -8,11 +8,14 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.ArrayList;
 import java.util.List;
+
+import game.Grid;
 import schelling.SchellingConfiguration.RoomValue;
 
 public class SchellingModel extends Game<RoomState> {
 
-    Queue<Cell<RoomState>> emptyRooms = new ArrayDeque<>();
+    Queue<Cell<RoomState>> emptyRooms;
+    Queue<Cell<RoomState>> initialEmptyRooms;
 
     public SchellingModel(int rows, int columns) {
         super(rows, columns);
@@ -27,6 +30,7 @@ public class SchellingModel extends Game<RoomState> {
             }
         }
 
+        this.initialEmptyRooms = new ArrayDeque<>(emptyRooms);
     }
 
     public SchellingModel(SchellingModel model) {
@@ -38,15 +42,6 @@ public class SchellingModel extends Game<RoomState> {
         this(50, 50);
     }
 
-    // Options
-    // 1. Use initial fn that collect all empty spaces at the beginning.
-    //  -> One more iteration loop for that
-    // 2. Override constructors
-    // -> Only one constructor needs to be overrided (Game(int rows, int cols))
-    // 3. Modify base class constructor...
-    // -> I could create instead of a state, a whole cell on each
-    // CONCLUSION: 2, because 1 implies 2, and 3 is modifying a base class
-
     @Override
     public RoomState newState() {
         return new RoomState();
@@ -54,26 +49,23 @@ public class SchellingModel extends Game<RoomState> {
 
     @Override
     public void nextState() {
-        SchellingModel game = new SchellingModel(getRows(), getColumns());
+        SchellingModel game = new SchellingModel(this);
         this.nextState(game);
     }
 
     @Override
     public RoomState cellNextState(Cell<RoomState> cell) {
-
+        assert(!cell.getState().getRoomValue().equals(RoomValue.EMPTY));
         //  1-Check if I want to change of neighborhood and there is a free place
-
         long undesirableNeighborCount = this.getCellNeighbors(cell).stream().filter(neighbor -> {
             RoomValue neighborType = neighbor.getState().getRoomValue();
             RoomValue myType = cell.getState().getRoomValue();
 
-            return !neighborType.equals(myType);
+            return !neighborType.equals(RoomValue.EMPTY) &&  !neighborType.equals(myType);
         }).count();
 
         if (undesirableNeighborCount > SchellingConfiguration.threshold && !emptyRooms.isEmpty()) {
             // IF EMPTY SPACE TO MOVE -> Actual cell become empty
-            // TODO: Take one cell from the empty list.
-            Cell<RoomState> emptyRoom = emptyRooms.poll();
             return new RoomState(RoomValue.EMPTY);
         }
 
@@ -94,18 +86,19 @@ public class SchellingModel extends Game<RoomState> {
         }
         // Update them
         for (Cell<RoomState> busyCell : busyRooms) {
-            RoomState nextCellState = this.cellNextState(busyCell);
+            RoomState nextCellState = this.cellNextState(busyCell); // empty or the same
             if (nextCellState.getRoomValue().equals(RoomValue.EMPTY)) {
                 // Pick an empty room
                 Cell<RoomState> newFamilyHouse = this.emptyRooms.poll();
                 // Warning because poll is not verified to be not null,
                 //but If I have a RoomValue.Empty, that means I already did the
                 // verification on the cellNextState, this should be improved.
-                newFamilyHouse.setState(busyCell.getState());
-                newState.grid.setCellState(newFamilyHouse.getX(), newFamilyHouse.getY(), newFamilyHouse.getState());
-                this.emptyRooms.add(busyCell);
+                //newFamilyHouse.setState(busyCell.getState());
+                newState.grid.setCellState(newFamilyHouse.getX(), newFamilyHouse.getY(), busyCell.getState().clone());
+                busyCell.setState(nextCellState.clone());
+                this.emptyRooms.add(busyCell.clone());
             }
-            newState.grid.setCellState(busyCell.getX(), busyCell.getY(), nextCellState);
+            newState.grid.setCellState(busyCell.getX(), busyCell.getY(), nextCellState.clone());
         }
 
         // TODO: I only need to update the grid, not the whole game.
@@ -128,5 +121,12 @@ public class SchellingModel extends Game<RoomState> {
                 Color.PINK;
             default -> Color.GRAY;
         };
+    }
+
+    // TODO: For the game restart I need to save the emptyRooms on an initialState.
+    @Override
+    public void restart() {
+        this.grid = new Grid<>(this.initialGrid);
+        this.emptyRooms = new ArrayDeque<>(this.initialEmptyRooms);
     }
 }

--- a/src/schelling/SchellingModel.java
+++ b/src/schelling/SchellingModel.java
@@ -8,6 +8,7 @@ import java.util.*;
 
 import game.Grid;
 import schelling.SchellingConfiguration.RoomValue;
+import static schelling.SchellingConfiguration.TOLERANCE_THRESHOLD;
 
 public class SchellingModel extends Game<RoomState> {
 
@@ -58,14 +59,12 @@ public class SchellingModel extends Game<RoomState> {
     @Override
     public RoomState cellNextState(Cell<RoomState> cell) {
         assert(!cell.getState().getRoomValue().equals(RoomValue.EMPTY));
-        long undesirableNeighborCount = this.getCellNeighbors(cell).stream().filter(neighbor -> {
-            RoomValue neighborType = neighbor.getState().getRoomValue();
-            RoomValue myType = cell.getState().getRoomValue();
+        RoomValue myType = cell.getState().getRoomValue();
+        long undesirableNeighborCount = this.getCellNeighbors(cell).stream()
+                .filter(maybeNeighbor -> !maybeNeighbor.getState().getRoomValue().equals(RoomValue.EMPTY))
+                .filter(neighbor -> !neighbor.getState().getRoomValue().equals(myType)).count();
 
-            return !neighborType.equals(RoomValue.EMPTY) &&  !neighborType.equals(myType);
-        }).count();
-
-        if (undesirableNeighborCount > SchellingConfiguration.threshold && !emptyRooms.isEmpty()) {
+        if (undesirableNeighborCount > TOLERANCE_THRESHOLD && !emptyRooms.isEmpty()) {
             return new RoomState(RoomValue.EMPTY);
         }
 
@@ -73,19 +72,25 @@ public class SchellingModel extends Game<RoomState> {
     }
 
     public void nextState(SchellingModel newState) {
-        List<Cell<RoomState>> busyRooms = collectBusyRooms();
-        for (Cell<RoomState> busyCell : busyRooms) {
+        for (Cell<RoomState> busyCell : collectBusyRooms()) {
             RoomState nextCellState = this.cellNextState(busyCell); // empty or the same
             if (nextCellState.getRoomValue().equals(RoomValue.EMPTY)) {
-                Cell<RoomState> newFamilyHouse = chooseEmptyRoom();
-                newState.grid.setCellState(newFamilyHouse.getX(), newFamilyHouse.getY(), busyCell.getState().clone());
-                busyCell.setState(nextCellState.clone());
-                this.emptyRooms.add(busyCell.clone());
+                Cell<RoomState> newBusyCell = moveBusyCellFamilyIntoEmptyRoom(busyCell);
+                newState.grid.setCellState(newBusyCell.getX(), newBusyCell.getY(), newBusyCell.getState());
             }
             newState.grid.setCellState(busyCell.getX(), busyCell.getY(), nextCellState.clone());
         }
 
         this.grid = newState.grid;
+    }
+
+    private Cell<RoomState> moveBusyCellFamilyIntoEmptyRoom(Cell<RoomState> busyCell) {
+        Cell<RoomState> newBusyCell = pollEmptyRoom();
+        Cell<RoomState> newEmptyRoom = new Cell<>(busyCell.getX(), busyCell.getY(), new RoomState(RoomValue.EMPTY));
+        newBusyCell.setState(busyCell.getState().clone());
+        this.emptyRooms.add(newEmptyRoom);
+
+        return newBusyCell;
     }
 
     private ArrayList<Cell<RoomState>> collectBusyRooms() {
@@ -99,11 +104,10 @@ public class SchellingModel extends Game<RoomState> {
                 }
             }
         }
-
         return busyRooms;
     }
 
-    private Cell<RoomState> chooseEmptyRoom() {
+    private Cell<RoomState> pollEmptyRoom() {
         Random random = new Random();
         int index = random.nextInt(this.emptyRooms.size());
         return this.emptyRooms.remove(index);

--- a/src/schelling/SchellingModel.java
+++ b/src/schelling/SchellingModel.java
@@ -1,0 +1,43 @@
+package schelling;
+
+import game.Cell;
+import game.Game;
+
+import java.awt.*;
+import java.util.PriorityQueue;
+import java.util.Random;
+
+public class SchellingModel extends Game<RoomState> {
+
+    private static final int FAMILY_TYPES = 5;
+    private int thresholdK = 6;
+    PriorityQueue<Cell<RoomState>> queue = new PriorityQueue<>();
+    @Override
+    public RoomState newState() {
+        Random rand = new Random();
+        int cellState = rand.nextInt(FAMILY_TYPES + 1);
+
+        // how to trick the randomizer to give me more 6 than anything else?
+        // I know, if it's 0 or 6, then is empty, the rest corresponds to the other. I see
+        // I include more possibilites that represents the emptiness.
+
+        return null;
+    }
+
+    @Override
+    public void nextState() {
+
+    }
+
+    @Override
+    public RoomState cellNextState(Cell<RoomState> cell) {
+
+
+        return null;
+    }
+
+    @Override
+    public Color getCellColor(int x, int y) {
+        return null;
+    }
+}

--- a/src/schelling/SchellingModel.java
+++ b/src/schelling/SchellingModel.java
@@ -3,32 +3,68 @@ package schelling;
 import game.Cell;
 import game.Game;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.PriorityQueue;
+import schelling.SchellingConfiguration.RoomValue;
 
 public class SchellingModel extends Game<RoomState> {
 
     PriorityQueue<Cell<RoomState>> queue = new PriorityQueue<>();
 
+    public SchellingModel(int rows, int columns) {
+        super(rows, columns);
+    }
+
     @Override
     public RoomState newState() {
+        // TODO: If RoomState is empty, insert the cell into the emptyCell queue
         return new RoomState();
     }
 
     @Override
     public void nextState() {
-
+        SchellingModel game = new SchellingModel(getRows(), getColumns());
+        this.nextState(game);
     }
 
     @Override
     public RoomState cellNextState(Cell<RoomState> cell) {
 
+        //  1-Check if I want to change of neighborhood
+        //  2-Search for a free place
+        //  3-Move to the free place // MODIFY THE FREE PLACE COLLECTION
 
-        return null;
+        long undesirableNeighborType = this.getCellNeighbors(cell).stream().filter(neighbor -> {
+            RoomValue neighborType = neighbor.getState().getRoomValue();
+            RoomValue myType = cell.getState().getRoomValue();
+
+            return !neighborType.equals(myType);
+        }).count();
+
+        if (undesirableNeighborType > SchellingConfiguration.threshold) {
+            // Actual cell become empty
+            // Take one cell from the empty list.
+            return new RoomState(RoomValue.EMPTY);
+        }
+
+        return new RoomState(cell.getState().getRoomValue());
     }
 
     @Override
     public Color getCellColor(int x, int y) {
-        return null;
+        Cell<RoomState> cell = this.grid.getCell(x,y);
+        return switch (cell.getState().getRoomValue()) {
+            case BLACK ->
+                Color.black;
+            case RED ->
+                Color.red;
+            case ORANGE ->
+                Color.ORANGE;
+            case YELLOW ->
+                Color.YELLOW;
+            case PINK ->
+                Color.PINK;
+            default -> Color.GRAY;
+        };
     }
 }

--- a/src/schelling/SchellingModel.java
+++ b/src/schelling/SchellingModel.java
@@ -4,38 +4,40 @@ import game.Cell;
 import game.Game;
 
 import java.awt.Color;
-import java.util.ArrayDeque;
-import java.util.Queue;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import game.Grid;
 import schelling.SchellingConfiguration.RoomValue;
 
 public class SchellingModel extends Game<RoomState> {
 
-    Queue<Cell<RoomState>> emptyRooms;
-    Queue<Cell<RoomState>> initialEmptyRooms;
+    // TODO: Instead of a List, I would like to randomize the empty room that a family choose to get
+    // In this case a hashmap could serve better for improving access time
+    // But how to get a random value from a hashmap or hashset?
+    List<Cell<RoomState>> emptyRooms;
+    List<Cell<RoomState>> initialEmptyRooms;
 
     public SchellingModel(int rows, int columns) {
         super(rows, columns);
 
-        // collectInitialEmptyRooms
-        this.emptyRooms = new ArrayDeque<>();
+        this.emptyRooms = new LinkedList<>();
+        this.initialEmptyRooms = new LinkedList<>();
+
         for (ArrayList<Cell<RoomState>> cell : this.grid.cells()) {
             for (Cell<RoomState> c : cell) {
-                if (c.getState().getRoomValue().equals(RoomValue.EMPTY))
-                    // TODO: I don't need new cells, only to track the (x,y) pos
+                if (c.getState().getRoomValue().equals(RoomValue.EMPTY)) {
                     emptyRooms.add(c.clone());
+                }
             }
         }
+        this.initialEmptyRooms = new LinkedList<>(emptyRooms);
 
-        this.initialEmptyRooms = new ArrayDeque<>(emptyRooms);
     }
 
     public SchellingModel(SchellingModel model) {
         super(model);
-        this.emptyRooms = new ArrayDeque<>(model.emptyRooms);
+        this.emptyRooms = new LinkedList<>(model.emptyRooms);
+        this.initialEmptyRooms = new LinkedList<>(model.initialEmptyRooms);
     }
 
     public SchellingModel() {
@@ -56,7 +58,6 @@ public class SchellingModel extends Game<RoomState> {
     @Override
     public RoomState cellNextState(Cell<RoomState> cell) {
         assert(!cell.getState().getRoomValue().equals(RoomValue.EMPTY));
-        //  1-Check if I want to change of neighborhood and there is a free place
         long undesirableNeighborCount = this.getCellNeighbors(cell).stream().filter(neighbor -> {
             RoomValue neighborType = neighbor.getState().getRoomValue();
             RoomValue myType = cell.getState().getRoomValue();
@@ -65,7 +66,6 @@ public class SchellingModel extends Game<RoomState> {
         }).count();
 
         if (undesirableNeighborCount > SchellingConfiguration.threshold && !emptyRooms.isEmpty()) {
-            // IF EMPTY SPACE TO MOVE -> Actual cell become empty
             return new RoomState(RoomValue.EMPTY);
         }
 
@@ -73,9 +73,24 @@ public class SchellingModel extends Game<RoomState> {
     }
 
     public void nextState(SchellingModel newState) {
-        // 1. Build non empty room list
-        List<Cell<RoomState>> busyRooms = new ArrayList<>();
+        List<Cell<RoomState>> busyRooms = collectBusyRooms();
+        for (Cell<RoomState> busyCell : busyRooms) {
+            RoomState nextCellState = this.cellNextState(busyCell); // empty or the same
+            if (nextCellState.getRoomValue().equals(RoomValue.EMPTY)) {
+                Cell<RoomState> newFamilyHouse = chooseEmptyRoom();
+                newState.grid.setCellState(newFamilyHouse.getX(), newFamilyHouse.getY(), busyCell.getState().clone());
+                busyCell.setState(nextCellState.clone());
+                this.emptyRooms.add(busyCell.clone());
+            }
+            newState.grid.setCellState(busyCell.getX(), busyCell.getY(), nextCellState.clone());
+        }
+
+        this.grid = newState.grid;
+    }
+
+    private ArrayList<Cell<RoomState>> collectBusyRooms() {
         // TODO: This could be an iterator over all members of grid.
+        ArrayList<Cell<RoomState>> busyRooms = new ArrayList<>();
         for  (int row = 0; row < getRows(); row++) {
             for (int column = 0; column < getColumns(); column++) {
                 Cell<RoomState> cell = this.grid.getCell(row, column);
@@ -84,25 +99,14 @@ public class SchellingModel extends Game<RoomState> {
                 }
             }
         }
-        // Update them
-        for (Cell<RoomState> busyCell : busyRooms) {
-            RoomState nextCellState = this.cellNextState(busyCell); // empty or the same
-            if (nextCellState.getRoomValue().equals(RoomValue.EMPTY)) {
-                // Pick an empty room
-                Cell<RoomState> newFamilyHouse = this.emptyRooms.poll();
-                // Warning because poll is not verified to be not null,
-                //but If I have a RoomValue.Empty, that means I already did the
-                // verification on the cellNextState, this should be improved.
-                //newFamilyHouse.setState(busyCell.getState());
-                newState.grid.setCellState(newFamilyHouse.getX(), newFamilyHouse.getY(), busyCell.getState().clone());
-                busyCell.setState(nextCellState.clone());
-                this.emptyRooms.add(busyCell.clone());
-            }
-            newState.grid.setCellState(busyCell.getX(), busyCell.getY(), nextCellState.clone());
-        }
 
-        // TODO: I only need to update the grid, not the whole game.
-        this.grid = newState.grid;
+        return busyRooms;
+    }
+
+    private Cell<RoomState> chooseEmptyRoom() {
+        Random random = new Random();
+        int index = random.nextInt(this.emptyRooms.size());
+        return this.emptyRooms.remove(index);
     }
 
     @Override
@@ -123,10 +127,9 @@ public class SchellingModel extends Game<RoomState> {
         };
     }
 
-    // TODO: For the game restart I need to save the emptyRooms on an initialState.
     @Override
     public void restart() {
         this.grid = new Grid<>(this.initialGrid);
-        this.emptyRooms = new ArrayDeque<>(this.initialEmptyRooms);
+        this.emptyRooms = new LinkedList<>(this.initialEmptyRooms);
     }
 }

--- a/src/schelling/SchellingModel.java
+++ b/src/schelling/SchellingModel.java
@@ -5,6 +5,7 @@ import game.Game;
 
 import java.awt.Color;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import game.Grid;
 import schelling.SchellingConfiguration.RoomValue;
@@ -20,19 +21,14 @@ public class SchellingModel extends Game<RoomState> {
 
     public SchellingModel(int rows, int columns) {
         super(rows, columns);
-
         this.emptyRooms = new LinkedList<>();
         this.initialEmptyRooms = new LinkedList<>();
 
-        for (ArrayList<Cell<RoomState>> cell : this.grid.cells()) {
-            for (Cell<RoomState> c : cell) {
-                if (c.getState().getRoomValue().equals(RoomValue.EMPTY)) {
-                    emptyRooms.add(c.clone());
-                }
-            }
-        }
+        this.emptyRooms = this.grid.stream()
+                        .filter(cell -> cell.getState().isRoomEmpty())
+                        .map(Cell::clone)
+                        .collect(Collectors.toCollection(LinkedList::new));
         this.initialEmptyRooms = new LinkedList<>(emptyRooms);
-
     }
 
     public SchellingModel(SchellingModel model) {
@@ -58,11 +54,14 @@ public class SchellingModel extends Game<RoomState> {
 
     @Override
     public RoomState cellNextState(Cell<RoomState> cell) {
-        assert(!cell.getState().getRoomValue().equals(RoomValue.EMPTY));
+        assert(!cell.getState().isRoomEmpty());
         RoomValue myType = cell.getState().getRoomValue();
-        long undesirableNeighborCount = this.getCellNeighbors(cell).stream()
-                .filter(maybeNeighbor -> !maybeNeighbor.getState().getRoomValue().equals(RoomValue.EMPTY))
-                .filter(neighbor -> !neighbor.getState().getRoomValue().equals(myType)).count();
+        long undesirableNeighborCount =
+                        this.getCellNeighbors(cell)
+                        .stream()
+                        .filter(maybeNeighbor -> !maybeNeighbor.getState().isRoomEmpty())
+                        .filter(neighbor -> !neighbor.getState().getRoomValue().equals(myType))
+                        .count();
 
         if (undesirableNeighborCount > TOLERANCE_THRESHOLD && !emptyRooms.isEmpty()) {
             return new RoomState(RoomValue.EMPTY);
@@ -74,7 +73,7 @@ public class SchellingModel extends Game<RoomState> {
     public void nextState(SchellingModel newState) {
         for (Cell<RoomState> busyCell : collectBusyRooms()) {
             RoomState nextCellState = this.cellNextState(busyCell); // empty or the same
-            if (nextCellState.getRoomValue().equals(RoomValue.EMPTY)) {
+            if (nextCellState.isRoomEmpty()) {
                 Cell<RoomState> newBusyCell = moveBusyCellFamilyIntoEmptyRoom(busyCell);
                 newState.grid.setCellState(newBusyCell.getX(), newBusyCell.getY(), newBusyCell.getState());
             }
@@ -95,16 +94,11 @@ public class SchellingModel extends Game<RoomState> {
 
     private ArrayList<Cell<RoomState>> collectBusyRooms() {
         // TODO: This could be an iterator over all members of grid.
-        ArrayList<Cell<RoomState>> busyRooms = new ArrayList<>();
-        for  (int row = 0; row < getRows(); row++) {
-            for (int column = 0; column < getColumns(); column++) {
-                Cell<RoomState> cell = this.grid.getCell(row, column);
-                if (!cell.getState().getRoomValue().equals(RoomValue.EMPTY)) {
-                    busyRooms.add(cell);
-                }
-            }
-        }
-        return busyRooms;
+        return this.grid
+                .stream()
+                .filter(cell -> !cell.getState().isRoomEmpty())
+                .collect(Collectors.toCollection(ArrayList::new));
+
     }
 
     private Cell<RoomState> pollEmptyRoom() {

--- a/src/schelling/SchellingModel.java
+++ b/src/schelling/SchellingModel.java
@@ -5,23 +5,14 @@ import game.Game;
 
 import java.awt.*;
 import java.util.PriorityQueue;
-import java.util.Random;
 
 public class SchellingModel extends Game<RoomState> {
 
-    private static final int FAMILY_TYPES = 5;
-    private int thresholdK = 6;
     PriorityQueue<Cell<RoomState>> queue = new PriorityQueue<>();
+
     @Override
     public RoomState newState() {
-        Random rand = new Random();
-        int cellState = rand.nextInt(FAMILY_TYPES + 1);
-
-        // how to trick the randomizer to give me more 6 than anything else?
-        // I know, if it's 0 or 6, then is empty, the rest corresponds to the other. I see
-        // I include more possibilites that represents the emptiness.
-
-        return null;
+        return new RoomState();
     }
 
     @Override

--- a/src/schelling/SchellingModel.java
+++ b/src/schelling/SchellingModel.java
@@ -4,20 +4,51 @@ import game.Cell;
 import game.Game;
 
 import java.awt.Color;
-import java.util.PriorityQueue;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.ArrayList;
+import java.util.List;
 import schelling.SchellingConfiguration.RoomValue;
 
 public class SchellingModel extends Game<RoomState> {
 
-    PriorityQueue<Cell<RoomState>> queue = new PriorityQueue<>();
+    Queue<Cell<RoomState>> emptyRooms = new ArrayDeque<>();
 
     public SchellingModel(int rows, int columns) {
         super(rows, columns);
+
+        // collectInitialEmptyRooms
+        this.emptyRooms = new ArrayDeque<>();
+        for (ArrayList<Cell<RoomState>> cell : this.grid.cells()) {
+            for (Cell<RoomState> c : cell) {
+                if (c.getState().getRoomValue().equals(RoomValue.EMPTY))
+                    // TODO: I don't need new cells, only to track the (x,y) pos
+                    emptyRooms.add(c.clone());
+            }
+        }
+
     }
+
+    public SchellingModel(SchellingModel model) {
+        super(model);
+        this.emptyRooms = new ArrayDeque<>(model.emptyRooms);
+    }
+
+    public SchellingModel() {
+        this(50, 50);
+    }
+
+    // Options
+    // 1. Use initial fn that collect all empty spaces at the beginning.
+    //  -> One more iteration loop for that
+    // 2. Override constructors
+    // -> Only one constructor needs to be overrided (Game(int rows, int cols))
+    // 3. Modify base class constructor...
+    // -> I could create instead of a state, a whole cell on each
+    // CONCLUSION: 2, because 1 implies 2, and 3 is modifying a base class
 
     @Override
     public RoomState newState() {
-        // TODO: If RoomState is empty, insert the cell into the emptyCell queue
         return new RoomState();
     }
 
@@ -30,24 +61,55 @@ public class SchellingModel extends Game<RoomState> {
     @Override
     public RoomState cellNextState(Cell<RoomState> cell) {
 
-        //  1-Check if I want to change of neighborhood
-        //  2-Search for a free place
-        //  3-Move to the free place // MODIFY THE FREE PLACE COLLECTION
+        //  1-Check if I want to change of neighborhood and there is a free place
 
-        long undesirableNeighborType = this.getCellNeighbors(cell).stream().filter(neighbor -> {
+        long undesirableNeighborCount = this.getCellNeighbors(cell).stream().filter(neighbor -> {
             RoomValue neighborType = neighbor.getState().getRoomValue();
             RoomValue myType = cell.getState().getRoomValue();
 
             return !neighborType.equals(myType);
         }).count();
 
-        if (undesirableNeighborType > SchellingConfiguration.threshold) {
-            // Actual cell become empty
-            // Take one cell from the empty list.
+        if (undesirableNeighborCount > SchellingConfiguration.threshold && !emptyRooms.isEmpty()) {
+            // IF EMPTY SPACE TO MOVE -> Actual cell become empty
+            // TODO: Take one cell from the empty list.
+            Cell<RoomState> emptyRoom = emptyRooms.poll();
             return new RoomState(RoomValue.EMPTY);
         }
 
         return new RoomState(cell.getState().getRoomValue());
+    }
+
+    public void nextState(SchellingModel newState) {
+        // 1. Build non empty room list
+        List<Cell<RoomState>> busyRooms = new ArrayList<>();
+        // TODO: This could be an iterator over all members of grid.
+        for  (int row = 0; row < getRows(); row++) {
+            for (int column = 0; column < getColumns(); column++) {
+                Cell<RoomState> cell = this.grid.getCell(row, column);
+                if (!cell.getState().getRoomValue().equals(RoomValue.EMPTY)) {
+                    busyRooms.add(cell);
+                }
+            }
+        }
+        // Update them
+        for (Cell<RoomState> busyCell : busyRooms) {
+            RoomState nextCellState = this.cellNextState(busyCell);
+            if (nextCellState.getRoomValue().equals(RoomValue.EMPTY)) {
+                // Pick an empty room
+                Cell<RoomState> newFamilyHouse = this.emptyRooms.poll();
+                // Warning because poll is not verified to be not null,
+                //but If I have a RoomValue.Empty, that means I already did the
+                // verification on the cellNextState, this should be improved.
+                newFamilyHouse.setState(busyCell.getState());
+                newState.grid.setCellState(newFamilyHouse.getX(), newFamilyHouse.getY(), newFamilyHouse.getState());
+                this.emptyRooms.add(busyCell);
+            }
+            newState.grid.setCellState(busyCell.getX(), busyCell.getY(), nextCellState);
+        }
+
+        // TODO: I only need to update the grid, not the whole game.
+        this.grid = newState.grid;
     }
 
     @Override

--- a/src/schelling/TestRoomState.java
+++ b/src/schelling/TestRoomState.java
@@ -1,0 +1,38 @@
+package schelling;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+import schelling.SchellingConfiguration.RoomValue;
+
+public class TestRoomState {
+
+    @Test
+    public void testRoomState(){
+        RoomState roomState = new RoomState();
+        float emptyRoomPorcentage = 0.0F;
+
+        for(int i = 0; i < 100; i++){
+            RoomValue room = RoomState.randomRoomValue();
+            if (room.equals(RoomValue.EMPTY))
+                emptyRoomPorcentage += 1;
+        }
+
+        System.out.println("emptyRoomPorcentage = " + emptyRoomPorcentage);
+    }
+
+    @Test
+    public void testRandomGenerator(){
+        Random random = new Random();
+        int cellState;
+        for(int i = 0; i < 100; i++){
+            cellState = random.nextInt(SchellingConfiguration.ROOM_VALUES_COUNT + 5);
+            Assert.assertTrue(cellState >= 0 && cellState < SchellingConfiguration.ROOM_VALUES_COUNT + 5);
+            System.out.println("Random value number #"+ i + ": " +cellState);
+
+        }
+
+
+    }
+}

--- a/src/schelling/TestSchellingModelSimulator.java
+++ b/src/schelling/TestSchellingModelSimulator.java
@@ -1,0 +1,19 @@
+package schelling;
+
+import game.Simulator;
+import gui.GUISimulator;
+import immigrationgame.ImmigrationGame;
+import immigrationgame.ImmigrationState;
+
+import java.awt.*;
+
+public class TestSchellingModelSimulator {
+    public static void main(String[] args) {
+        GUISimulator gui = new GUISimulator(0, 0, Color.BLACK);
+
+        SchellingModel game = new SchellingModel();
+        Simulator<RoomState> simulator = new Simulator<>(gui, game);
+        gui.setSize(game.getDisplayWidth(), game.getDisplayHeight() + 70);
+        simulator.draw();
+    }
+}


### PR DESCRIPTION
# Schelling model implementation

## Goal

The goal of this PR was to implement the schelling model with the objective of reusing the maximum of code in common with the already developed games

## What I Did

1. Used the common code available on the Game class
2. Adapt `nextState`1 calculation on the schelling model
3. Define model specific entities
4. Randomize `chooseEmptyRoom` policy
5. Update makefile
6. Create a `GridIterator` and made `Grid` implement `Iterable<Cell<TState>>`


## Challenges

This is the most different game from the previous ones, due to the next state calculations and "side effect" implications.
Probably it could be further optimized in many aspects, but I think I will stop here to go into Boids.
